### PR TITLE
Feature/icon

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -37,8 +37,8 @@ class RegisteredUserController extends Controller
     {
         $validated = $request->validated();
         
-        $User = User::find(1);
-        if ($User->emailExists($validated['email'])){
+        $user = new User;
+        if ($user->emailExists($validated['email'])){
             throw ValidationException::withMessages([
                 'email' => ['既に登録されているメールアドレスです。'],
             ]);
@@ -51,10 +51,8 @@ class RegisteredUserController extends Controller
         ]);
         //iconを登録した場合
         if ($request->file('icon') !== null){
-            $userDetails = new UserDetail();
-            $userDetails->icon = $request->file('icon')->store('icons', 'public');
-            $userDetails->user_id = $user->id;
-            $userDetails->save();
+            $icon = new UserDetail(['icon' => $request->file('icon')->store('icons', 'public')]);
+            $user->userDetail()->save($icon);
         }
 
         event(new Registered($user));

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -13,6 +13,9 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
 use Illuminate\View\View;
 use App\Http\Requests\RegisterRequest;
+use App\Models\UserDetail;
+use Illuminate\Support\Facades\Log;
+
 
 
 class RegisteredUserController extends Controller
@@ -32,13 +35,26 @@ class RegisteredUserController extends Controller
      */
     public function store(RegisterRequest $request): RedirectResponse
     {
-        $input = $request->validated();
+        $validated = $request->validated();
         
+        if(User::where('email', $validated['email'])->exists()){
+            return redirect()->back()->with('message', '既に登録されているメールアドレスです');
+        }
+
         $user = User::create([
-            'name' => $input->name,
-            'email' => $input->email,
-            'password' => Hash::make($input->password),
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+            'password' => Hash::make($validated['password']),
         ]);
+        //iconを登録した場合
+        if ($request->file('icon') !== null){
+            $icon = new UserDetail();
+            $icon->icon = basename($request->file('icon')->store('icons', 'public'));
+            //Userテーブルからidを検索
+            $user_id = User::where('email', $validated['email'])->first();
+            $icon->user_id = $user_id->id;
+            $icon->save();
+        }
 
         event(new Registered($user));
 

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -37,8 +37,7 @@ class RegisteredUserController extends Controller
     {
         $validated = $request->validated();
         
-        $user = new User;
-        if ($user->emailExists($validated['email'])){
+        if (User::emailExists($validated['email'])){
             throw ValidationException::withMessages([
                 'email' => ['既に登録されているメールアドレスです。'],
             ]);

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
 use Illuminate\View\View;
+use App\Http\Requests\RegisterRequest;
+
 
 class RegisteredUserController extends Controller
 {
@@ -28,18 +30,14 @@ class RegisteredUserController extends Controller
      *
      * @throws \Illuminate\Validation\ValidationException
      */
-    public function store(Request $request): RedirectResponse
+    public function store(RegisterRequest $request): RedirectResponse
     {
-        $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:'.User::class],
-            'password' => ['required', 'confirmed', Rules\Password::defaults()],
-        ]);
-
+        $input = $request->validated();
+        
         $user = User::create([
-            'name' => $request->name,
-            'email' => $request->email,
-            'password' => Hash::make($request->password),
+            'name' => $input->name,
+            'email' => $input->email,
+            'password' => Hash::make($input->password),
         ]);
 
         event(new Registered($user));

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -14,8 +14,8 @@ use Illuminate\Validation\Rules;
 use Illuminate\View\View;
 use App\Http\Requests\RegisterRequest;
 use App\Models\UserDetail;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Support\Facades\Log;
-
 
 
 class RegisteredUserController extends Controller
@@ -37,8 +37,11 @@ class RegisteredUserController extends Controller
     {
         $validated = $request->validated();
         
-        if(User::where('email', $validated['email'])->exists()){
-            return redirect()->back()->with('message', '既に登録されているメールアドレスです');
+        $User = User::find(1);
+        if ($User->emailExists($validated['email'])){
+            throw ValidationException::withMessages([
+                'email' => ['既に登録されているメールアドレスです。'],
+            ]);
         }
 
         $user = User::create([

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -51,12 +51,10 @@ class RegisteredUserController extends Controller
         ]);
         //iconを登録した場合
         if ($request->file('icon') !== null){
-            $icon = new UserDetail();
-            $icon->icon = basename($request->file('icon')->store('icons', 'public'));
-            //Userテーブルからidを検索
-            $user_id = User::where('email', $validated['email'])->first();
-            $icon->user_id = $user_id->id;
-            $icon->save();
+            $userDetails = new UserDetail();
+            $userDetails->icon = basename($request->file('icon')->store('icons', 'public'));
+            $userDetails->user_id = $user->id;
+            $userDetails->save();
         }
 
         event(new Registered($user));

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -52,7 +52,7 @@ class RegisteredUserController extends Controller
         //iconを登録した場合
         if ($request->file('icon') !== null){
             $userDetails = new UserDetail();
-            $userDetails->icon = basename($request->file('icon')->store('icons', 'public'));
+            $userDetails->icon = $request->file('icon')->store('icons', 'public');
             $userDetails->user_id = $user->id;
             $userDetails->save();
         }

--- a/app/Http/Requests/RegisterRequest.php
+++ b/app/Http/Requests/RegisterRequest.php
@@ -14,7 +14,7 @@ class RegisterRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**

--- a/app/Http/Requests/RegisterRequest.php
+++ b/app/Http/Requests/RegisterRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\File;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules;
+
+class RegisterRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:'.User::class],
+            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+            'icon' =>[
+                File::types(['gif','jpg'])
+                ->min(1024)
+                ->max(12 * 1024)
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/RegisterRequest.php
+++ b/app/Http/Requests/RegisterRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests;
 
+use App\Models\User;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules\File;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules;
@@ -26,7 +28,7 @@ class RegisterRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:'.User::class],
+            'email' => ['required', 'string', 'email', 'max:255'],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
             'icon' =>[
                 File::types(['gif','jpg'])

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -49,4 +49,9 @@ class User extends Authenticatable
             ->exists();
         return $emailExists;
     }
+
+    public function userDetail()
+    {
+        return $this->hasOne(UserDetail::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -42,7 +42,7 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
-    public function emailExists(string $email)
+    public function emailExists(string $email): bool
     {
         $emailExists = self::query()
             ->where('email', '=', $email)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -42,4 +42,11 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+    public function emailExists(string $email)
+    {
+        $emailExists = self::query()
+            ->where('email', '=', $email)
+            ->exists();
+        return $emailExists;
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use App\Models\UserDetail;
 
 class User extends Authenticatable
 {
@@ -42,7 +43,7 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
-    public function emailExists(string $email): bool
+    public static function emailExists(string $email): bool
     {
         $emailExists = self::query()
             ->where('email', '=', $email)
@@ -50,7 +51,7 @@ class User extends Authenticatable
         return $emailExists;
     }
 
-    public function userDetail()
+    public function userDetail(): object
     {
         return $this->hasOne(UserDetail::class);
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 use App\Models\UserDetail;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class User extends Authenticatable
 {
@@ -51,7 +52,7 @@ class User extends Authenticatable
         return $emailExists;
     }
 
-    public function userDetail(): object
+    public function userDetail(): HasOne
     {
         return $this->hasOne(UserDetail::class);
     }

--- a/app/Models/UserDetail.php
+++ b/app/Models/UserDetail.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class UserDetail extends Model
+{
+    use HasFactory;
+    
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'user_id',
+        'icon',
+    ];
+}

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -11,6 +11,7 @@
     "Current Password": "現在のパスワード",
     "New Password": "新しいパスワード",
     "Confirm Password": "パスワードを再入力",
+    "Icon": "アイコン",
     "Please confirm your password before continuing.": "続けるにはパスワードを確認してください",
     "Update Password": "パスワードの更新",
     "Ensure your account is using a long, random password to stay secure.": "十分に長くランダムなパスワードを使用して、アカウントのセキュリティを高めましょう",

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,5 +1,5 @@
 <x-guest-layout>
-    <form method="POST" action="{{ route('register') }}">
+    <form method="POST" action="{{ route('register') }}" enctype="multipart/form-data">
         @csrf
 
         <!-- Name -->
@@ -37,6 +37,16 @@
                             name="password_confirmation" required autocomplete="new-password" />
 
             <x-input-error :messages="$errors->get('password_confirmation')" class="mt-2" />
+        </div>
+        <!-- icon -->
+        <div class="mt-4">
+            <x-input-label for="icon" :value="__('Icon')" />
+
+            <x-file-input id="icon" class="block mt-1 m-auto"
+                            type="file"
+                            name="icon" />
+
+            <x-input-error :messages="$errors->get('icon')" class="mt-2" />
         </div>
 
         <div class="flex items-center justify-end mt-4">

--- a/resources/views/components/file-input.blade.php
+++ b/resources/views/components/file-input.blade.php
@@ -1,0 +1,3 @@
+@props(['disabled' => false])
+
+<input {{ $disabled ? 'disabled' : '' }} {!! $attributes->merge(['class' => 'border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300']) !!}>


### PR DESCRIPTION
概要
breezeインストール時に既に存在する会員登録機能にアイコンを登録できる機能を加えました。
変更点
- ファイルアップロード用のコンポーネントresources/views/components/file-input.blade.phpを作成し、resources/views/auth/register.blade.phpを修正して、アイコンん登録フォームを設置した。
- ユーザのアイコンを保存するuser_detailsテーブルに対応するモデルapp/Models/UserDetail.phpを作成した。
- 会員登録時のバリデーション機能をapp/Http/Requests/RegisterRequest.phpに移行し、FromRequestを用いたバリデーションに変更した。
- app/Http/Controllers/Auth/RegisteredUserController.phpを変更し、DBに会員情報を登録できるように変更した。

懸念点
既にあるメールアドレスを登録したときにエラ〜メッセージを表示せずに登録画面に戻ってきてしまっている。